### PR TITLE
ruff check exception for Jupyter notebooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       run: uv sync
     
     - name: Run ruff format check
-      run: uv run ruff format --check
+      run: uv run ruff format --check --exclude "*.ipynb"
     
     - name: Run ruff check
-      run: uv run ruff check
+      run: uv run ruff check --exclude "*.ipynb"


### PR DESCRIPTION
Jupyter notebook code is typically experimental and explorative. It would be counter productive to put the same linting standards as production code.